### PR TITLE
Replace PathMap.normalisePath with the one from alhadis.utils

### DIFF
--- a/lib/path-map.js
+++ b/lib/path-map.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const instanceData = new WeakMap();
+const {normalisePath} = require("alhadis.utils");
 const {posix, win32} = require("path");
 
 
@@ -37,22 +38,8 @@ class PathMap extends Map {
 	 */
 	filterPath(input){
 		if(!input) return "";
-		if(this.forcePosix) input = this.normalisePath(input);
+		if(this.forcePosix) input = normalisePath(input);
 		if(this.ignoreCase) input = input.toLowerCase();
-		return this.trimSlash(input);
-	}
-	
-	
-	/**
-	 * Resolve a path and replace backslashes with forward-slashes.
-	 *
-	 * @internal
-	 * @param {String} input
-	 * @return {String}
-	 */
-	normalisePath(input){
-		input = win32.normalize(input || "").replace(/\\/g, "/");
-		input = posix.normalize(input);
 		return this.trimSlash(input);
 	}
 
@@ -106,7 +93,7 @@ class PathMap extends Map {
 	set(key, value){
 		const data = instanceData.get(this);
 		data.set(this.filterPath(key), value);
-		return super.set(this.normalisePath(key), value);
+		return super.set(normalisePath(key), value);
 	}
 	
 	
@@ -141,7 +128,7 @@ class PathMap extends Map {
 	delete(key){
 		const data = instanceData.get(this);
 		data.delete(this.filterPath(key));
-		return super.delete(this.normalisePath(key));
+		return super.delete(normalisePath(key));
 	}
 }
 

--- a/lib/path-map.js
+++ b/lib/path-map.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const instanceData = new WeakMap();
-const {normalisePath} = require("alhadis.utils");
 const {posix, win32} = require("path");
 
 
@@ -38,8 +37,24 @@ class PathMap extends Map {
 	 */
 	filterPath(input){
 		if(!input) return "";
-		if(this.forcePosix) input = normalisePath(input);
-		if(this.ignoreCase) input = input.toLowerCase();
+		if(!/^\w*:\/\//.test(input)){
+			if(this.forcePosix) input = this.normalisePath(input);
+			if(this.ignoreCase) input = input.toLowerCase();
+		}
+		return this.trimSlash(input);
+	}
+	
+	
+	/**
+	 * Resolve a path and replace backslashes with forward-slashes.
+	 *
+	 * @internal
+	 * @param {String} input
+	 * @return {String}
+	 */
+	normalisePath(input){
+		input = win32.normalize(input || "").replace(/\\/g, "/");
+		input = posix.normalize(input);
 		return this.trimSlash(input);
 	}
 
@@ -93,7 +108,7 @@ class PathMap extends Map {
 	set(key, value){
 		const data = instanceData.get(this);
 		data.set(this.filterPath(key), value);
-		return super.set(normalisePath(key), value);
+		return super.set(this.normalisePath(key), value);
 	}
 	
 	
@@ -128,7 +143,7 @@ class PathMap extends Map {
 	delete(key){
 		const data = instanceData.get(this);
 		data.delete(this.filterPath(key));
-		return super.delete(normalisePath(key));
+		return super.delete(this.normalisePath(key));
 	}
 }
 


### PR DESCRIPTION
`PathMap` currently has a different `normalisePath` implementation from
the one that the `Resource` class uses, leading to a mismatch between
`PathMap` keys and resource paths. This can lead to bugs where a
resource is marked as disposed but not removed from the `PathMap`;
attempting to fetch it again leads to exceptions from the null `icon`.